### PR TITLE
Fix willClose and didClose on tableview

### DIFF
--- a/Samples/iOS/Swift/IOS-SDK-Demo-App/Ad Formats/LOBannerViewController.swift
+++ b/Samples/iOS/Swift/IOS-SDK-Demo-App/Ad Formats/LOBannerViewController.swift
@@ -50,6 +50,11 @@ class LOBannerViewController: UIViewController {
     
     @IBAction func btnPressed(_ sender:UIButton) {
         if sender == loadBtn {
+            if self.bannerAd != nil {
+                self.bannerAd?.delegate = nil
+                self.bannerAd = nil
+                AppUtil.resetLogMessage(tableView: self.tableView, callbacks: self.callbackLogs)
+            }
             guard let placementId = self.placementId else {
                 return
             }
@@ -72,10 +77,6 @@ class LOBannerViewController: UIViewController {
             for subView in self.bannerAdContainer.subviews {
                 subView.removeFromSuperview()
             }
-            self.bannerAd?.delegate = nil
-            self.bannerAd = nil
-            
-            AppUtil.resetLogMessage(tableView: self.tableView, callbacks: self.callbackLogs)
         }
     }
 }

--- a/Samples/iOS/Swift/IOS-SDK-Demo-App/Ad Formats/LOMRECViewController.swift
+++ b/Samples/iOS/Swift/IOS-SDK-Demo-App/Ad Formats/LOMRECViewController.swift
@@ -25,6 +25,11 @@ class LOMRECViewController: LOBannerViewController {
     
     override func btnPressed(_ sender: UIButton) {
         if sender == self.loadBtn {
+            if self.mrecAd != nil {
+                self.mrecAd?.delegate = nil
+                self.mrecAd = nil
+                AppUtil.resetLogMessage(tableView: self.tableView, callbacks: self.callbackLogs)
+            }
             guard let placementId = self.placementId else {
                 return
             }
@@ -40,10 +45,6 @@ class LOMRECViewController: LOBannerViewController {
             for subViews in self.bannerAdContainer.subviews {
                 subViews.removeFromSuperview()
             }
-            self.mrecAd?.delegate = nil
-            self.mrecAd = nil
-            
-            AppUtil.resetLogMessage(tableView: self.tableView, callbacks: self.callbackLogs)
         }
     }
 }

--- a/Samples/iOS/Swift/IOS-SDK-Demo-App/Ad Formats/LONativeAdViewController.swift
+++ b/Samples/iOS/Swift/IOS-SDK-Demo-App/Ad Formats/LONativeAdViewController.swift
@@ -60,6 +60,13 @@ class LONativeAdViewController: UIViewController {
     
     @IBAction func btnPressed(_ sender: UIButton) {
         if sender == self.loadBtn {
+            if self.nativeAd != nil {
+                self.nativeAd?.delegate = nil
+                self.nativeAd = nil
+                
+                AppUtil.resetLogMessage(tableView: self.tableView, callbacks: self.callbackLogs)
+            }
+            
             guard let placementId = self.placementId else {
                 return
             }
@@ -84,8 +91,6 @@ class LONativeAdViewController: UIViewController {
             }
         } else if sender == self.closeBtn {
             self.nativeAd?.unregisterView()
-            self.nativeAd?.delegate = nil
-            self.nativeAd = nil
             
             // Reset the values inside the labels
             self.titleLbl.text = "App Title"
@@ -93,8 +98,6 @@ class LONativeAdViewController: UIViewController {
             self.sponsorLbl.text = "Sponsored by Text"
             self.adTextLbl.text = "Body Text"
             self.downloadBtn.setTitle("CTA Text", for: .normal)
-            
-            AppUtil.resetLogMessage(tableView: self.tableView, callbacks: self.callbackLogs)
         }
     }
     


### PR DESCRIPTION
We want to show willClose & didClose callback fires correctly before the tableView resets. I changed the timing so that when the publisher loads a new ad, the callbacks inside the tableView will reset. 