### PR TITLE
Adds CocoaPods specific lines to gitignore

### DIFF
--- a/Samples/iOS/Swift/.gitignore
+++ b/Samples/iOS/Swift/.gitignore
@@ -31,3 +31,8 @@ DerivedData/
 ## Playgrounds
 timeline.xctimeline
 playground.xcworkspace
+
+# CocoaPods
+Pods/
+*.xcworkspace
+

--- a/Samples/iOS/Swift/.gitignore
+++ b/Samples/iOS/Swift/.gitignore
@@ -1,6 +1,7 @@
 # Xcode
 
 ## User settings
+.DS_Store
 xcuserdata/
 
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
@@ -33,6 +34,7 @@ timeline.xctimeline
 playground.xcworkspace
 
 # CocoaPods
+Podfile.lock
 Pods/
 *.xcworkspace
 


### PR DESCRIPTION
This will allow for ignoring the Pods project directory and the `*.xcworkspace` file, which will allow for full testing in the local branch before committing changes and pushing to remote.