### PR TITLE
[IOS-6233]Fix Native ad MeidaView crash

### DIFF
--- a/Samples/iOS/Objective-C/IOS-SDK-Demo-App/Main.storyboard
+++ b/Samples/iOS/Objective-C/IOS-SDK-Demo-App/Main.storyboard
@@ -850,7 +850,7 @@
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="89y-vo-TxN" userLabel="Native Ad View">
                                                 <rect key="frame" x="8" y="95" width="377" height="422"/>
                                                 <subviews>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q8I-0t-sEd">
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q8I-0t-sEd" customClass="MediaView">
                                                         <rect key="frame" x="8" y="97" width="361" height="228"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <constraints>

--- a/Samples/iOS/Objective-C/IOS-SDK-Demo-App/Main.storyboard
+++ b/Samples/iOS/Objective-C/IOS-SDK-Demo-App/Main.storyboard
@@ -850,7 +850,7 @@
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="89y-vo-TxN" userLabel="Native Ad View">
                                                 <rect key="frame" x="8" y="95" width="377" height="422"/>
                                                 <subviews>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q8I-0t-sEd" customClass="MediaView">
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q8I-0t-sEd" customClass="MediaView" customModule="VungleAdsSDK">
                                                         <rect key="frame" x="8" y="97" width="361" height="228"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <constraints>

--- a/Samples/iOS/Swift/IOS-SDK-Demo-App/Base.lproj/Main.storyboard
+++ b/Samples/iOS/Swift/IOS-SDK-Demo-App/Base.lproj/Main.storyboard
@@ -341,7 +341,7 @@
                                                             <constraint firstAttribute="width" constant="90" id="qRW-cb-3lt"/>
                                                         </constraints>
                                                     </imageView>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ct5-YK-CwY">
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ct5-YK-CwY" customClass="MediaView">
                                                         <rect key="frame" x="8" y="102" width="398" height="228"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <constraints>

--- a/Samples/iOS/Swift/IOS-SDK-Demo-App/Base.lproj/Main.storyboard
+++ b/Samples/iOS/Swift/IOS-SDK-Demo-App/Base.lproj/Main.storyboard
@@ -341,7 +341,7 @@
                                                             <constraint firstAttribute="width" constant="90" id="qRW-cb-3lt"/>
                                                         </constraints>
                                                     </imageView>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ct5-YK-CwY" customClass="MediaView">
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ct5-YK-CwY" customClass="MediaView" customModule="VungleAdsSDK">
                                                         <rect key="frame" x="8" y="102" width="398" height="228"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <constraints>


### PR DESCRIPTION
This commit will fix a Native ad crash which is caused by Storyboard setting a wrong media view type.

IOS-6233