### PR TITLE
Update podfiles so latest SDK version can be installed

### DIFF
--- a/Samples/iOS/Objective-C/Podfile
+++ b/Samples/iOS/Objective-C/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '10.0'
+platform :ios, '11.0'
 
 target 'IOS-SDK-Demo-App' do
   pod 'VungleAds'

--- a/Samples/iOS/Swift/Podfile
+++ b/Samples/iOS/Swift/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '10.0'
+platform :ios, '11.0'
 
 target 'IOS-SDK-Demo-App' do
    pod 'VungleAds'


### PR DESCRIPTION
The podfiles used in the Swift and objective-c sample projects need to be updated so they both list iOS 11.0 for the platform parameter. Because the latest VungleAds SDK requires iOS 11 or higher, `pod update` will not install the latest.