### PR TITLE
Update Android SDK to 7.7.5

### DIFF
--- a/CHANGELOG-Android.md
+++ b/CHANGELOG-Android.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Vungle SDK for Android/Amazon 7.7.5 (July 6, 2026)
+* Stability Improvements
+* Performance Improvements
+
 ## Vungle SDK for Android/Amazon 7.7.4 (May 12, 2026)
 * Stability Improvements
 

--- a/Samples/android/Java/app-v7-java/build.gradle
+++ b/Samples/android/Java/app-v7-java/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation 'com.android.support:multidex:1.0.3'
 
     // Vungle SDK
-    implementation 'com.vungle:vungle-ads:7.7.4'
+    implementation 'com.vungle:vungle-ads:7.7.5'
 
     // Recommended Google Play Services libraries to support app set ID (v6.10.3 and above)
     implementation 'com.google.android.gms:play-services-tasks:18.0.2'

--- a/Samples/android/Kotlin/app-v7-kotlin/build.gradle
+++ b/Samples/android/Kotlin/app-v7-kotlin/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 
     // Vungle SDK
-    implementation 'com.vungle:vungle-ads:7.7.4'
+    implementation 'com.vungle:vungle-ads:7.7.5'
 
     // Recommended Google Play Services libraries to support app set ID (v6.10.3 and above)
     implementation 'com.google.android.gms:play-services-tasks:18.0.2'


### PR DESCRIPTION
Updates Vungle Android SDK to 7.7.5 in Kotlin/Java sample apps and prepends CHANGELOG entry.