### PR TITLE
Update Android SDK to 7.7.7

### DIFF
--- a/CHANGELOG-Android.md
+++ b/CHANGELOG-Android.md
@@ -1,7 +1,6 @@
 # Changelog
 
-## Vungle SDK for Android/Amazon 7.7.7 (July 23, 2026)
-* Added "Contains AI" label to Native Ads
+## Vungle SDK for Android/Amazon 7.7.7 (July 24, 2026)
 * Stability Improvements
 
 ## Vungle SDK for Android/Amazon 7.7.6 (July 13, 2026)

--- a/CHANGELOG-Android.md
+++ b/CHANGELOG-Android.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Vungle SDK for Android/Amazon 7.7.7 (July 23, 2026)
+* Added "Contains AI" label to Native Ads
+* Stability Improvements
+
 ## Vungle SDK for Android/Amazon 7.7.6 (July 13, 2026)
 * Stability Improvements
 

--- a/Samples/android/Java/app-v7-java/build.gradle
+++ b/Samples/android/Java/app-v7-java/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation 'com.android.support:multidex:1.0.3'
 
     // Vungle SDK
-    implementation 'com.vungle:vungle-ads:7.7.6'
+    implementation 'com.vungle:vungle-ads:7.7.7'
 
     // Recommended Google Play Services libraries to support app set ID (v6.10.3 and above)
     implementation 'com.google.android.gms:play-services-tasks:18.0.2'

--- a/Samples/android/Kotlin/app-v7-kotlin/build.gradle
+++ b/Samples/android/Kotlin/app-v7-kotlin/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 
     // Vungle SDK
-    implementation 'com.vungle:vungle-ads:7.7.6'
+    implementation 'com.vungle:vungle-ads:7.7.7'
 
     // Recommended Google Play Services libraries to support app set ID (v6.10.3 and above)
     implementation 'com.google.android.gms:play-services-tasks:18.0.2'


### PR DESCRIPTION
Updates Vungle Android SDK to 7.7.7 in Kotlin/Java sample apps and prepends CHANGELOG entry.